### PR TITLE
trim node version from .nvmrc

### DIFF
--- a/tasks/nvm/alias-default.js
+++ b/tasks/nvm/alias-default.js
@@ -31,6 +31,7 @@ module.exports = function (gruntOrShipit) {
       .then(function (res) {
 
         v = remote ? res[0].stdout : res.stdout;
+        v = v.trim();
 
         return shipit[method](
           sprintf('. %s && nvm use %s && nvm alias default %s', shipit.config.nvm.sh, v, v)


### PR DESCRIPTION
Most editore either add a trailing new line and/or hide an existing trailing newline.

This cause the following error :

```
Running ". ~/.nvm/nvm.sh && nvm use 4.2.2
 && nvm alias default 4.2.2
" on host "localhost".
@localhost Now using node v4.2.2 (npm v2.14.7)
@localhost-err bash: -c: line 1: syntax error near unexpected token `&&'
@localhost-err bash: -c: line 1: ` && nvm alias default 4.2.2'
Error: Command failed: /bin/sh -c ssh xyz@localhost ". ~/.nvm/nvm.sh && nvm use 4.2.2
 && nvm alias default 4.2.2
"
bash: -c: line 1: syntax error near unexpected token `&&'
bash: -c: line 1: ` && nvm alias default 4.2.2'
```
